### PR TITLE
Add Order model and CRUD endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,13 @@ A minimal CRUD application using FastAPI, SQLAlchemy and PostgreSQL, with absolu
 - **app/main.py**: Application entrypoint.
 - **app/api/routers.py**: API routes.
 - **app/schemas/user_schema.py**: Pydantic schemas.
+- **app/schemas/order_schema.py**: Order Pydantic schemas.
 - **app/models/user.py**: SQLAlchemy ORM models.
+- **app/models/order.py**: Order ORM model.
 - **app/repositories/user_repository.py**: Database operations.
+- **app/repositories/order_repository.py**: Order database operations.
 - **app/services/user_service.py**: Business logic.
+- **app/services/order_service.py**: Order business logic.
 - **app/db/session.py**: Database session and connection.
 - **app/db/base.py**: Declarative base.
 
@@ -52,15 +56,19 @@ A minimal CRUD application using FastAPI, SQLAlchemy and PostgreSQL, with absolu
     │   └── session.py
     ├── models
     │   ├── __init__.py
+    │   ├── order.py
     │   └── user.py
     ├── repositories
     │   ├── __init__.py
+    │   ├── order_repository.py
     │   └── user_repository.py
     ├── schemas
     │   ├── __init__.py
+    │   ├── order_schema.py
     │   └── user_schema.py
     └── services
         ├── __init__.py
+        ├── order_service.py
         └── user_service.py
 ```
 
@@ -113,10 +121,10 @@ uvicorn app.main:app --reload
 
 FastAPI automatically generates interactive docs:
 
-- **Swagger UI**:  http://127.0.0.1:8000/docs  
+- **Swagger UI**:  http://127.0.0.1:8000/docs
 - **ReDoc**:       http://127.0.0.1:8000/redoc
 
-Here you can perform all CRUD operations on the `/users` endpoint.
+Here you can perform all CRUD operations on the `/users` and `/orders` endpoints.
 
 ### 5. Example Requests
 
@@ -148,6 +156,36 @@ curl -X PUT "http://127.0.0.1:8000/users/1"      -H "Content-Type: application/j
 
 ```bash
 curl -X DELETE http://127.0.0.1:8000/users/1
+```
+
+#### Create an order
+
+```bash
+curl -X POST "http://127.0.0.1:8000/orders/"      -H "Content-Type: application/json"      -d '{"item":"Book","quantity":1}'
+```
+
+#### List all orders
+
+```bash
+curl http://127.0.0.1:8000/orders/
+```
+
+#### Get a single order
+
+```bash
+curl http://127.0.0.1:8000/orders/1
+```
+
+#### Update an order
+
+```bash
+curl -X PUT "http://127.0.0.1:8000/orders/1"      -H "Content-Type: application/json"      -d '{"item":"Notebook","quantity":2}'
+```
+
+#### Delete an order
+
+```bash
+curl -X DELETE http://127.0.0.1:8000/orders/1
 ```
 
 > **Tip**: You can also use HTTPie for nicer syntax:

--- a/README.md
+++ b/README.md
@@ -13,11 +13,16 @@
       * [Get a single user](#get-a-single-user)
       * [Update a user](#update-a-user)
       * [Delete a user](#delete-a-user)
+      * [Create an order](#create-an-order)
+      * [List all orders](#list-all-orders)
+      * [Get a single order](#get-a-single-order)
+      * [Update an order](#update-an-order)
+      * [Delete an order](#delete-an-order)
 <!-- TOC -->
 
 # FastAPI PostgreSQL CRUD Example
 
-A minimal CRUD application using FastAPI, SQLAlchemy and PostgreSQL, with absolute imports and a clear project structure.
+A minimal CRUD application using FastAPI, SQLAlchemy and PostgreSQL, featuring CRUD operations for managing users and orders.
 
 ## Prerequisites
 

--- a/app/api/routers.py
+++ b/app/api/routers.py
@@ -2,31 +2,73 @@ from fastapi import APIRouter, Depends, HTTPException
 from typing import List
 
 from app.schemas.user_schema import UserCreate, User as UserSchema
+from app.schemas.order_schema import OrderCreate, Order as OrderSchema
 from app.services.user_service import UserService
+from app.services.order_service import OrderService
 from app.db.session import get_db
 
-router = APIRouter(prefix='/users', tags=['users'])
+router = APIRouter()
+user_router = APIRouter(prefix='/users', tags=['users'])
+order_router = APIRouter(prefix='/orders', tags=['orders'])
 
-@router.post('/', response_model=UserSchema)
+
+@user_router.post('/', response_model=UserSchema)
 def create_user(user: UserCreate, db=Depends(get_db)):
     return UserService(db).create_user(user)
 
-@router.get('/', response_model=List[UserSchema])
+
+@user_router.get('/', response_model=List[UserSchema])
 def list_users(db=Depends(get_db)):
     return UserService(db).get_users()
 
-@router.get('/{user_id}', response_model=UserSchema)
+
+@user_router.get('/{user_id}', response_model=UserSchema)
 def get_user(user_id: int, db=Depends(get_db)):
     user = UserService(db).get_user(user_id)
     if not user:
         raise HTTPException(status_code=404, detail='User not found')
     return user
 
-@router.put('/{user_id}', response_model=UserSchema)
+
+@user_router.put('/{user_id}', response_model=UserSchema)
 def update_user(user_id: int, user: UserCreate, db=Depends(get_db)):
     return UserService(db).update_user(user_id, user)
 
-@router.delete('/{user_id}')
+
+@user_router.delete('/{user_id}')
 def delete_user(user_id: int, db=Depends(get_db)):
     UserService(db).delete_user(user_id)
     return {'ok': True}
+
+
+@order_router.post('/', response_model=OrderSchema)
+def create_order(order: OrderCreate, db=Depends(get_db)):
+    return OrderService(db).create_order(order)
+
+
+@order_router.get('/', response_model=List[OrderSchema])
+def list_orders(db=Depends(get_db)):
+    return OrderService(db).get_orders()
+
+
+@order_router.get('/{order_id}', response_model=OrderSchema)
+def get_order(order_id: int, db=Depends(get_db)):
+    order = OrderService(db).get_order(order_id)
+    if not order:
+        raise HTTPException(status_code=404, detail='Order not found')
+    return order
+
+
+@order_router.put('/{order_id}', response_model=OrderSchema)
+def update_order(order_id: int, order: OrderCreate, db=Depends(get_db)):
+    return OrderService(db).update_order(order_id, order)
+
+
+@order_router.delete('/{order_id}')
+def delete_order(order_id: int, db=Depends(get_db)):
+    OrderService(db).delete_order(order_id)
+    return {'ok': True}
+
+
+router.include_router(user_router)
+router.include_router(order_router)

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+
+from app.db.base import Base
+
+class Order(Base):
+    __tablename__ = 'orders'
+
+    id = Column(Integer, primary_key=True, index=True)
+    item = Column(String, nullable=False)
+    quantity = Column(Integer, nullable=False)

--- a/app/repositories/order_repository.py
+++ b/app/repositories/order_repository.py
@@ -1,0 +1,32 @@
+from sqlalchemy.orm import Session
+
+from app.models.order import Order
+from app.schemas.order_schema import OrderCreate
+
+class OrderRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(self, order: OrderCreate):
+        db_order = Order(item=order.item, quantity=order.quantity)
+        self.db.add(db_order)
+        self.db.commit()
+        self.db.refresh(db_order)
+        return db_order
+
+    def get(self, order_id: int):
+        return self.db.query(Order).filter(Order.id == order_id).first()
+
+    def list(self):
+        return self.db.query(Order).all()
+
+    def update(self, order: Order, order_data: OrderCreate):
+        order.item = order_data.item
+        order.quantity = order_data.quantity
+        self.db.commit()
+        self.db.refresh(order)
+        return order
+
+    def delete(self, order: Order):
+        self.db.delete(order)
+        self.db.commit()

--- a/app/schemas/order_schema.py
+++ b/app/schemas/order_schema.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+class OrderBase(BaseModel):
+    item: str
+    quantity: int
+
+class OrderCreate(OrderBase):
+    pass
+
+class Order(OrderBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/services/order_service.py
+++ b/app/services/order_service.py
@@ -1,0 +1,25 @@
+from sqlalchemy.orm import Session
+
+from app.repositories.order_repository import OrderRepository
+from app.schemas.order_schema import OrderCreate
+
+class OrderService:
+    def __init__(self, db: Session):
+        self.repository = OrderRepository(db)
+
+    def create_order(self, order_data: OrderCreate):
+        return self.repository.create(order_data)
+
+    def get_order(self, order_id: int):
+        return self.repository.get(order_id)
+
+    def get_orders(self):
+        return self.repository.list()
+
+    def update_order(self, order_id: int, order_data: OrderCreate):
+        order = self.repository.get(order_id)
+        return self.repository.update(order, order_data)
+
+    def delete_order(self, order_id: int):
+        order = self.repository.get(order_id)
+        self.repository.delete(order)


### PR DESCRIPTION
## Summary
- add Order SQLAlchemy model
- implement Order repository, service, and API routes for CRUD operations
- document Order API in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6894ae5e435c8322980ac7e6f9e5aafb